### PR TITLE
Improve simulator capacity reporting. The device capacity and remaining

### DIFF
--- a/kinetic-simulator/src/main/java/com/seagate/kinetic/simulator/internal/GetLogHandler.java
+++ b/kinetic-simulator/src/main/java/com/seagate/kinetic/simulator/internal/GetLogHandler.java
@@ -108,7 +108,7 @@ public class GetLogHandler {
 
             switch (type) {
             case CAPACITIES:
-                Capacity capacity = CapacityUtil.getCapacity();
+                Capacity capacity = CapacityUtil.getCapacity(engine);
                 getLog.setCapacity(capacity);
                 break;
             case UTILIZATIONS:

--- a/kinetic-simulator/src/main/java/com/seagate/kinetic/simulator/internal/SimulatorEngine.java
+++ b/kinetic-simulator/src/main/java/com/seagate/kinetic/simulator/internal/SimulatorEngine.java
@@ -904,5 +904,24 @@ public class SimulatorEngine implements MessageService {
     public boolean getDeviceLocked() {
         return this.deviceLocked;
     }
+    
+    /**
+     * Get the absolute path of the persist store.
+     * 
+     * @return the absolute path of the persist store
+     * 
+     */
+    public String getPersistStorePath() {
+
+        String path = "/";
+
+        try {
+            path = this.store.getPersistStorePath();
+        } catch (KVStoreException e) {
+            logger.log(Level.WARNING, e.getMessage(), e);
+        }
+
+        return path;
+    }
 
 }

--- a/kinetic-simulator/src/main/java/com/seagate/kinetic/simulator/persist/Store.java
+++ b/kinetic-simulator/src/main/java/com/seagate/kinetic/simulator/persist/Store.java
@@ -29,10 +29,13 @@ import com.seagate.kinetic.simulator.internal.KVStoreException;
 
 /**
  *
- * DB Application (Raw) Interface.
- *
+ * Kinetic persist store (Raw) Interface.
+ * 
+ * @see StoreFactory 
+ * 
  * @author James Hughes.
  * @author Chenchong Li
+ * @author Chiaming Yang
  */
 public interface Store<K, O, V> {
 
@@ -257,4 +260,13 @@ public interface Store<K, O, V> {
      *            if null then compaction ends at the last key
      */
     public void compactRange(K startKey, K endKey) throws KVStoreException;
+    
+    /**
+     * Get the absolute path of the persist store.
+     * 
+     * @return the absolute path of the persist store
+     * 
+     * @throws KVStoreException if any internal error occurred.
+     */
+    public String getPersistStorePath() throws KVStoreException;
 }

--- a/kinetic-simulator/src/main/java/com/seagate/kinetic/simulator/persist/bdb/BdbStore.java
+++ b/kinetic-simulator/src/main/java/com/seagate/kinetic/simulator/persist/bdb/BdbStore.java
@@ -33,7 +33,7 @@ import com.seagate.kinetic.simulator.persist.PersistOption;
 import com.seagate.kinetic.simulator.persist.Store;
 
 /**
- * implement store
+ * Implement Kinetic Store interface.
  *
  * XXX chiaming 12/24/2013: support PersistOption
  *
@@ -161,6 +161,11 @@ public class BdbStore implements Store<ByteString, ByteString, KVValue> {
             throws KVStoreException {
         // TODO Auto-generated method stub
         logger.warning("method is not implemented for bdb");
+    }
+    
+    @Override
+    public String getPersistStorePath() throws KVStoreException {
+        return this.kvStore.getPersistStorePath();
     }
 
 }

--- a/kinetic-simulator/src/main/java/com/seagate/kinetic/simulator/persist/bdb/KVStore.java
+++ b/kinetic-simulator/src/main/java/com/seagate/kinetic/simulator/persist/bdb/KVStore.java
@@ -61,6 +61,8 @@ public final class KVStore {
 	private Database myDatabase = null;
 	private final DatabaseConfig dbConfig = new DatabaseConfig();
 	private String kineticDbName = null;
+	
+	private String persistFolder = null;
 
 	static DatabaseEntry dbe(String s) {
 		ByteString bs = ByteString.copyFromUtf8(s);
@@ -98,7 +100,7 @@ public final class KVStore {
 					+ ", created=" + created);
 		}
 
-		String persistFolder = kineticHome
+		persistFolder = kineticHome
 				+ File.separator
 				+ config.getProperty(SimulatorConfiguration.PERSIST_HOME, "bdb");
 
@@ -353,5 +355,16 @@ public final class KVStore {
 			throw new KVStoreException("DB internal exception");
 		}
 	}
+	
+    /**
+     * Get persist store path.
+     * 
+     * @return persist store path.
+     * @throws KVStoreException
+     *             if any internal error occurred.
+     */
+    public String getPersistStorePath() throws KVStoreException {
+        return this.persistFolder;
+    }
 
 }

--- a/kinetic-simulator/src/main/java/com/seagate/kinetic/simulator/persist/kyoto/KyotoCabinet.java
+++ b/kinetic-simulator/src/main/java/com/seagate/kinetic/simulator/persist/kyoto/KyotoCabinet.java
@@ -59,6 +59,8 @@ public class KyotoCabinet implements Store<ByteString, ByteString, KVValue> {
             .getLogger(KyotoCabinet.class.getName());
 
     private DB db = null;
+    
+    private String persistFolder = null;
 
     public KyotoCabinet() {
         ;
@@ -81,7 +83,7 @@ public class KyotoCabinet implements Store<ByteString, ByteString, KVValue> {
                     + ", created=" + created);
         }
 
-        String persistFolder = kineticHome
+        persistFolder = kineticHome
                 + File.separator
                 + config.getProperty(SimulatorConfiguration.PERSIST_HOME,
                         "kyoto");
@@ -494,6 +496,11 @@ public class KyotoCabinet implements Store<ByteString, ByteString, KVValue> {
     public void compactRange(ByteString startKey, ByteString endKey)
             throws KVStoreException {
         logger.warning("method is not yet implemented.");
+    }
+    
+    @Override
+    public String getPersistStorePath() throws KVStoreException {
+        return this.persistFolder;
     }
 
 }

--- a/kinetic-simulator/src/main/java/com/seagate/kinetic/simulator/persist/leveldb/LevelDbStore.java
+++ b/kinetic-simulator/src/main/java/com/seagate/kinetic/simulator/persist/leveldb/LevelDbStore.java
@@ -80,6 +80,8 @@ public class LevelDbStore implements Store<ByteString, ByteString, KVValue> {
     // async write option
     private static final WriteOptions asyncWriteOption = new WriteOptions()
             .sync(false);
+    
+    private String persistFolder = null;
 
     // default no-arg constructor
     public LevelDbStore() {
@@ -105,14 +107,15 @@ public class LevelDbStore implements Store<ByteString, ByteString, KVValue> {
                     + ", created=" + created);
         }
 
-        String persistFolder = kineticHome
+        // calculate persist folder
+        persistFolder = kineticHome
                 + File.separator
                 + config.getProperty(SimulatorConfiguration.PERSIST_HOME,
                         "leveldb");
 
         File f = new File(persistFolder);
 
-        logger.info("Database exists: " + f.exists() + ", name="
+        logger.info("Database exists: " + f.exists() + ", persist folder ="
                 + persistFolder);
 
         if (f.exists() == false) {
@@ -778,6 +781,11 @@ public class LevelDbStore implements Store<ByteString, ByteString, KVValue> {
         } catch (Exception e) {
             throw new KVStoreException(e.getMessage());
         }
+    }
+
+	@Override
+    public String getPersistStorePath() throws KVStoreException {
+        return this.persistFolder;
     }
 
 }

--- a/kinetic-simulator/src/main/java/com/seagate/kinetic/simulator/persist/memory/MemoryStore.java
+++ b/kinetic-simulator/src/main/java/com/seagate/kinetic/simulator/persist/memory/MemoryStore.java
@@ -68,6 +68,9 @@ public class MemoryStore implements Store<ByteString, ByteString, KVValue> {
 
     // server config
     private SimulatorConfiguration config = null;
+    
+    // persist folder
+    private String persistFolder = null;
 
     /**
      * default constructor
@@ -348,7 +351,7 @@ public class MemoryStore implements Store<ByteString, ByteString, KVValue> {
         }
 
         // persist home
-        String persistFolder = kineticHome
+        persistFolder = kineticHome
                 + File.separator
                 + config.getProperty(SimulatorConfiguration.PERSIST_HOME,
                         "memory");
@@ -418,6 +421,11 @@ public class MemoryStore implements Store<ByteString, ByteString, KVValue> {
             throws KVStoreException {
         // no op
         ;
+    }
+    
+    @Override
+    public String getPersistStorePath() throws KVStoreException {
+        return this.persistFolder;
     }
 
 }

--- a/kinetic-simulator/src/main/java/com/seagate/kinetic/simulator/utility/CapacityUtil.java
+++ b/kinetic-simulator/src/main/java/com/seagate/kinetic/simulator/utility/CapacityUtil.java
@@ -24,6 +24,7 @@ import java.io.File;
 import java.util.logging.Logger;
 
 import com.seagate.kinetic.proto.Kinetic.Command.GetLog.Capacity;
+import com.seagate.kinetic.simulator.internal.SimulatorEngine;
 
 /**
  *
@@ -42,12 +43,15 @@ public abstract class CapacityUtil {
 
     //private static long MB = 1000000;
 
-    public static Capacity getCapacity() {
+    public static Capacity getCapacity(SimulatorEngine engine) {
 
         Capacity capacity = null;
 
         try {
-            File file = new File("/");
+            // get store path
+            String storePath = engine.getPersistStorePath();
+        	
+            File file = new File(storePath);
 
             long total = file.getTotalSpace();
 

--- a/kinetic-test/src/test/java/com/seagate/kinetic/example/simulator/SingleKineticSimulator.java
+++ b/kinetic-test/src/test/java/com/seagate/kinetic/example/simulator/SingleKineticSimulator.java
@@ -35,15 +35,30 @@ import kinetic.simulator.SimulatorConfiguration;
  */
 public class SingleKineticSimulator {
 
-	public static void main(String[] args) {
-		SimulatorConfiguration config = new SimulatorConfiguration();
-		KineticSimulator simulator = new KineticSimulator(config);
+    public static void main(String[] args) {
 
-		System.out.println("Example simulator started on port="
-				+ simulator.getServerConfiguration().getPort()
-				+ ", SSL/TLS port="
-				+ simulator.getServerConfiguration().getSslPort());
-	}
+        SimulatorConfiguration serverConfig = new SimulatorConfiguration();
 
+        int port = 8123;
+
+        if (args.length > 0) {
+            port = Integer.parseInt(args[0]);
+        }
+
+        serverConfig.setPort(port);
+
+        if (args.length > 1) {
+            serverConfig.setProperty(SimulatorConfiguration.KINETIC_HOME, args[1]);
+        }
+
+        if (args.length > 2) {
+            serverConfig.setSslPort(Integer.parseInt(args[2]));
+        }
+
+        KineticSimulator simulator = new KineticSimulator(serverConfig);
+
+        System.out.println("Example simulator started on port=" + simulator.getServerConfiguration().getPort()
+                + ", SSL/TLS port=" + simulator.getServerConfiguration().getSslPort());
+    }
 
 }


### PR DESCRIPTION
information are calculated based on the persistent store path. 

A simulator instantiated on different path/partition will now report its
capacity information based on the store's path/partition.