### PR TITLE
Fix for issue #32 - asyncQueuedSize is not always respected.

### DIFF
--- a/kinetic-client/src/main/java/com/seagate/kinetic/client/io/MessageHandler.java
+++ b/kinetic-client/src/main/java/com/seagate/kinetic/client/io/MessageHandler.java
@@ -321,15 +321,12 @@ public class MessageHandler implements ClientMessageService, Runnable {
 		Long seq = Long.valueOf(message.getCommand().getHeader()
 				.getSequence());
 
-        // synchronized (this) {
-			while (this.ackmap.size() >= this.asyncQueuedSize && this.isRunning) {
-				this.wait();
-            // }
+		while (ackmap.size() >= asyncQueuedSize && (isClosed == false)) {
+			this.wait();
 		}
 
 		this.ackmap.put(seq, context);
-
-		// this.iohandler.write(message);
+		
 		this.doWrite(message);
 	}
 


### PR DESCRIPTION
Fix for issue #32.  

isClosed flag is checked so that the client runtime can exit should concurrent PUT and close() are called.

    while (ackmap.size() >= asyncQueuedSize && (isClosed == false)) {                      
        this.wait();
    }